### PR TITLE
Bug1159 calendar index

### DIFF
--- a/src/utils/__tests__/calendarDates.test.js
+++ b/src/utils/__tests__/calendarDates.test.js
@@ -8,6 +8,7 @@ import {
   checkLocationDays,
   getDaysOfWeekForLocation,
   dateSetFromString,
+  firstValidDay,
 } from '../calendarDates'
 
 // describe('Utilities functions CalendarDates.js', () => {
@@ -110,4 +111,13 @@ it('Handles single date string', () => {
   const set = dateSetFromString('2018-10-03')
   expect(set.has('2018-10-03')).toEqual(true)
 })
-// })
+
+it('Knows not to block the first day after a weekend', () => {
+  const firstValidDayAfterWeekend = firstValidDay(
+    undefined,
+    new Date('Sunday, September 22, 2019'),
+  )
+  expect(firstValidDayAfterWeekend).toEqual(
+    new Date('Monday, September 23, 2019'),
+  )
+})

--- a/src/utils/calendarDates.js
+++ b/src/utils/calendarDates.js
@@ -30,6 +30,9 @@ export const toLocale = (date, options, locale) => {
  *--------------------------------------------*/
 
 export const getStartDate = (today = new Date()) => {
+  if (today.getDate() === 21) {
+    console.log('Break here lol')
+  }
   today.setDate(today.getDate() + 1)
   const date = firstValidDay(undefined, addWeeks(today, offsetStartWeeks))
   return dateToISODateString(date)

--- a/src/utils/calendarDates.js
+++ b/src/utils/calendarDates.js
@@ -30,9 +30,6 @@ export const toLocale = (date, options, locale) => {
  *--------------------------------------------*/
 
 export const getStartDate = (today = new Date()) => {
-  if (today.getDate() === 21) {
-    console.log('Break here lol')
-  }
   today.setDate(today.getDate() + 1)
   const date = firstValidDay(undefined, addWeeks(today, offsetStartWeeks))
   return dateToISODateString(date)

--- a/src/utils/calendarDates.js
+++ b/src/utils/calendarDates.js
@@ -70,8 +70,7 @@ export const getInitialMonth = (selectedDates, startMonth) => {
    is valid for a location
 */
 export const firstValidDay = (location = getGlobalLocation(), date) => {
-  var i = 0
-  for (i = 0; i <= 7; i++) {
+  for (var i = 0; i <= 7; i++) {
     let plusDay = addDays(date, i)
     //check for valid day for the location
     const month = getShortMonthName(date)

--- a/src/utils/calendarDates.js
+++ b/src/utils/calendarDates.js
@@ -30,9 +30,6 @@ export const toLocale = (date, options, locale) => {
  *--------------------------------------------*/
 
 export const getStartDate = (today = new Date()) => {
-  if (today.getDate() === 21) {
-    console.log('Break here lol')
-  }
   today.setDate(today.getDate() + 1)
   const date = firstValidDay(undefined, addWeeks(today, offsetStartWeeks))
   return dateToISODateString(date)
@@ -82,8 +79,6 @@ export const firstValidDay = (location = getGlobalLocation(), date) => {
     if (isValidDayForLocation(location, month, plusDay)) {
       break
     }
-
-    i++
   }
 
   return parse(addDays(date, i))


### PR DESCRIPTION
Fixes bug #1159.
The bug was caused by a loop in "calendarDates.js" in the function `firstValidDay`.
There was an increment to the iterator inside of the for loop, as well as in its signature, Which would cause the loop to skip by 2 days if the first run didnt return `true` and break the loop.