### PR TITLE
Setting Time 0 to empty string

### DIFF
--- a/src/pages/CalendarPage.js
+++ b/src/pages/CalendarPage.js
@@ -133,6 +133,7 @@ class CalendarPage extends Component {
   }
 
   updateTime(id) {
+    if( id === "0" ) id = "";
     this.setState({ timeValue: id })
   }
   forceRender(values) {


### PR DESCRIPTION
Since the validator is looking for any non-empty strings as the time, I figured it was easiest to set the time value to be empty string when it is 0.