### PR TITLE
Get and Display Actual Timeslot Availability

### DIFF
--- a/src/components/TimeSlots.js
+++ b/src/components/TimeSlots.js
@@ -42,9 +42,11 @@ class TimeSlots extends Component {
   }
 
   getNewestTimeslots() {
-    let accessible = this.props.context.store.register.accessibility[0]
-      ? true
-      : false
+    let userSelection = this.props.context.store.register.accessibility
+    let accessible = true
+    if (!userSelection || userSelection[0] === undefined) {
+      accessible = false
+    }
     let locationId = this.props.context.store.selectProvince.locationId
     let selectedDay = moment(this.props.selectedDay[0]).format('YYYY-MM-DD')
     let values = {

--- a/src/components/TimeSlots.js
+++ b/src/components/TimeSlots.js
@@ -18,6 +18,7 @@ class TimeSlots extends Component {
       selectedId: 0,
       appointments: [],
       selectedDay: [],
+      timeSlots: [],
     }
     this.changeHandler = this.changeHandler.bind(this)
     this.getNewestTimeslots = this.getNewestTimeslots.bind(this)
@@ -32,26 +33,6 @@ class TimeSlots extends Component {
         } = {},
       } = {},
     } = this.props
-  }
-
-  removeTimeSlot(mockData) {
-    const dbTimeSlots = this.state.appointments
-    const TimeSlotArray = mockData
-
-    for (var i = 0; i < TimeSlotArray.length; i++) {
-      for (var j = 0; j < dbTimeSlots.length; j++) {
-        if (
-          // eslint-disable-next-line security/detect-object-injection
-          dbTimeSlots[j].time.toString() ===
-          // eslint-disable-next-line security/detect-object-injection
-          TimeSlotArray[i].name.toString()
-        ) {
-          TimeSlotArray.splice(i, 1)
-        }
-      }
-    }
-
-    return TimeSlotArray
   }
 
   changeHandler(event) {
@@ -79,6 +60,7 @@ class TimeSlots extends Component {
           ...values,
           timeSlots,
         }
+        this.setState({ timeSlots: timeSlots })
         await this.props.context.setStore('calendar', values)
       })
   }
@@ -96,10 +78,6 @@ class TimeSlots extends Component {
   }
 
   render() {
-    const timeSlot = this.removeTimeSlot(
-      this.props.context.store.calendar.timeSlots,
-    )
-
     return (
       <div id="select-time" className={selectDropDown}>
         <SelectDropDown
@@ -108,7 +86,7 @@ class TimeSlots extends Component {
           optName1="Select a time"
           selOnChange={this.changeHandler}
           selOnClick={this.getNewestTimeslots}
-          optData={timeSlot}
+          optData={this.state.timeSlots}
         />
       </div>
     )

--- a/src/components/TimeSlots.js
+++ b/src/components/TimeSlots.js
@@ -6,6 +6,7 @@ import moment from 'moment'
 import SelectDropDown from '../components/forms/Select'
 import { css } from 'emotion'
 import axios from 'axios'
+import { logError } from '../utils/logger'
 
 const selectDropDown = css`
   max-width: 500px;
@@ -64,6 +65,9 @@ class TimeSlots extends Component {
         }
         this.setState({ timeSlots: timeSlots })
         await this.props.context.setStore('calendar', values)
+      })
+      .catch(err => {
+        logError(err)
       })
   }
 

--- a/src/components/forms/Select.js
+++ b/src/components/forms/Select.js
@@ -46,6 +46,7 @@ class SelectDropDown extends React.Component {
         id={this.props.selId}
         defaultValue="0"
         onChange={this.props.selOnChange}
+        onClick={this.props.selOnClick}
       >
         <option key="0" value="0">
           {this.props.optName1}
@@ -64,6 +65,7 @@ SelectDropDown.propTypes = {
   selName: PropTypes.string,
   selId: PropTypes.string,
   selOnChange: PropTypes.func,
+  selOnClick: PropTypes.func,
   optName1: PropTypes.string,
   optData: PropTypes.array,
 }

--- a/src/components/forms/Select.js
+++ b/src/components/forms/Select.js
@@ -51,7 +51,7 @@ class SelectDropDown extends React.Component {
         <option key="0" value="0">
           {this.props.optName1}
         </option>
-        {this.props.optData
+        {Array.isArray(this.props.optData)
           ? this.props.optData.map(({ name, value }) => (
               <option key={value} value={value}>
                 {name}

--- a/src/components/forms/Select.js
+++ b/src/components/forms/Select.js
@@ -51,11 +51,13 @@ class SelectDropDown extends React.Component {
         <option key="0" value="0">
           {this.props.optName1}
         </option>
-        {this.props.optData.map(({ name, value }) => (
-          <option key={value} value={value}>
-            {name}
-          </option>
-        ))}
+        {this.props.optData
+          ? this.props.optData.map(({ name, value }) => (
+              <option key={value} value={value}>
+                {name}
+              </option>
+            ))
+          : null}
       </select>
     )
   }

--- a/src/server.js
+++ b/src/server.js
@@ -104,6 +104,31 @@ server
         res.status(503).send()
       })
   })
+  .get('/appointments/timeslots/:locationId', (req, res) => {
+    let locationId = req.params.locationId
+    let day = req.query.day
+    let accessible = req.query.accessible
+    let data = ''
+    http
+      .get(
+        `${apiHost}/appointments/timeslots/${locationId}?day=${day}&accessible=${accessible}`,
+        resp => {
+          logDebug(`STATUS: ${resp.statusCode}`)
+          logDebug(`HEADERS: ${JSON.stringify(resp.headers)}`)
+          resp.on('data', chunk => {
+            data += chunk
+            res.status(200).send(data)
+          })
+        },
+      )
+      .on('error', err => {
+        logError(
+          'Something went wrong when calling the API appointments/timeslots:  ' +
+            err.message,
+        )
+        res.status(503).send()
+      })
+  })
   .post('/appointments/temp', (req, res) => {
     let data = JSON.stringify(req.body)
     const options = {

--- a/src/validation.js
+++ b/src/validation.js
@@ -125,6 +125,7 @@ export const CalendarFields = {
   selectedTime: 'required',
   tempAppointment: 'accept_anything',
   availability: 'accept_anything',
+  timeSlots: 'accept_anything',
 }
 
 export const SelectLocationFields = {


### PR DESCRIPTION
Timeslots dropdown now has onClick that gets the newest data for available timeslots and uses that to render the list of options. Works for both regular and accessible timeslots.

There is a bug where when the dropdown is first selected, that it flashes and disappears and must be clicked again. I believe this is a matter of the retrieved data being passed into the dropdown component after it has initially rendered and the change forces it to re-render, causing this behaviour. I have logged the bug in azuredevops and assigned myself and will continue working on it.

I think it is still worth merging this in its current state, as it is central to the overall flow of the application.